### PR TITLE
Delta update

### DIFF
--- a/check-next-missing-timestamp.js
+++ b/check-next-missing-timestamp.js
@@ -1,0 +1,70 @@
+const Influx = require('influx')
+
+let writeLog = (message) => process.stderr.write(message + '\n')
+let defaultDateTimeStr = process.env.START_DATE_DEFAULT || "2024-01-01:00:00+00:00"
+
+getSchemaDefinition = function () {
+  return [
+    {
+      measurement: 'carunaplus_consumption',
+      fields: {
+        'totalConsumption': Influx.FieldType.FLOAT,
+        'invoicedConsumption': Influx.FieldType.FLOAT,
+        'daytimeConsumption': Influx.FieldType.FLOAT,
+        'nighttimeConsumption': Influx.FieldType.FLOAT,
+        'totalFee': Influx.FieldType.FLOAT,
+        'distributionFee': Influx.FieldType.FLOAT,
+        'distributionBaseFee': Influx.FieldType.FLOAT,
+        'electricityTax': Influx.FieldType.FLOAT,
+        'valueAddedTax': Influx.FieldType.FLOAT,
+        'temperature': Influx.FieldType.FLOAT,
+      },
+      tags: [
+        'assetId',
+      ]
+    }
+  ]
+}
+
+const requiredEnvVars = [
+    'INFLUX_HOST',
+    'INFLUX_DATABASE',
+    'INFLUX_USERNAME',
+    'INFLUX_PASSWORD',
+]
+for (const envVar of requiredEnvVars) {
+    if (!process.env[envVar]) {
+        throw new Error(`${requiredEnvVars.join(', ')} must be specified`)
+    }
+}
+
+writeLog("Creating InfluxDB instance")
+const influx = new Influx.InfluxDB({
+    host: process.env.INFLUX_HOST,
+    database: process.env.INFLUX_DATABASE,
+    username: process.env.INFLUX_USERNAME,
+    password: process.env.INFLUX_PASSWORD,
+    schema: getSchemaDefinition(),
+})
+writeLog(`Created InfluxDB instance ${process.env.INFLUX_USERNAME}@${process.env.INFLUX_HOST}/${process.env.INFLUX_DATABASE}`)
+
+writeLog('Getting database names')
+influx.getDatabaseNames().then((names) => {
+    writeLog(`Got database names ${names.join(',')}`)
+    if (!names.includes(process.env.INFLUX_DATABASE)) {
+        throw new Error(`The specified database "${process.env.INFLUX_DATABASE}" does not exist`)
+    }
+    influx.query(`SELECT last(totalConsumption), time FROM carunaplus_consumption;`).then(result => {
+        var dateTimeStr = ""
+        if(result.length < 0) {
+            writeLog(`No timestamp found in influxdb! Defaulting to ${defaultDateTimeStr}`)
+            dateTimeStr = defaultDateTimeStr
+        } else {
+            dateTimeStr = result[0].time
+        }
+        let dateTime = new Date((new Date(dateTimeStr)).getTime() + 86400000)
+        process.stdout.write(
+        `${dateTime.getFullYear()} ${dateTime.getMonth()+1} ${dateTime.getDate()}\n`
+        )
+    })
+})

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/Jalle19/pycaruna.git@64a4cb4a9559f6985f8f2b422ef62591bcc799ee#egg=pycaruna==0.0.1
+pycaruna==1.0.2

--- a/update_influxdb.sh
+++ b/update_influxdb.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+VARIABLE_CHECK_OK=1
+ensure_variables() {
+    for VARIABLE in "$@"; do
+        if [[ -z ${!VARIABLE} ]]; then
+            echo "Please set ${VARIABLE}" >&2
+            VARIABLE_CHECK_OK=0
+        fi
+    done
+    if [[ $VARIABLE_CHECK_OK -ne 1 ]]; then
+        echo "Missing environment variables" >&2
+        exit 1
+    fi
+}
+
+ensure_variables INFLUX_HOST INFLUX_USERNAME INFLUX_PASSWORD INFLUX_DATABASE CARUNA_USERNAME CARUNA_PASSWORD
+set -u
+
+DATE=$(node check-next-missing-timestamp.js)
+CONSUMPTION_DATA=$(python3 get_consumption_data.py $DATE)
+node caruna-influxdb.js <<< "$CONSUMPTION_DATA"


### PR DESCRIPTION
Add scripts to automatically only request missing points.

The javacript `check-next-missing-timestamp.js` queries influxdb to find out the timestamp of the newest existing record, and adds one day, then outputs this date in the same format as get_consumption_date.py expects as parameters.

The shellscript `update_influxdb.sh` fetches only inexistent records from caruna.

This can be used to easily automate pulling data from Caruna.

Cheers