### PR TITLE
Bump pycaruna from [git] 0.0.1 to pypi 1.0.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/Jalle19/pycaruna.git@64a4cb4a9559f6985f8f2b422ef62591bcc799ee#egg=pycaruna==0.0.1
+pycaruna==1.0.2


### PR DESCRIPTION
Fixed PR #5 by using own branch for this fix

requirements.txt included an old version of pycaruna which did not work. In addition to this, the dependency was pulled from git, instead of pypi. Bumped version and changed source to pypi.